### PR TITLE
Fix duplicated changed-files list + show commit time in history

### DIFF
--- a/usr/share/build-package/gui/widgets/advanced_widget.py
+++ b/usr/share/build-package/gui/widgets/advanced_widget.py
@@ -236,9 +236,11 @@ class AdvancedWidget(Gtk.Box):
         try:
             import subprocess
             
-            # Get recent commits
+            # Get recent commits. Use a date format that includes the time (in
+            # local timezone) so the history shows hour:minute, not just the
+            # day — the full hash is carried too (shown truncated by CommitRow).
             result = subprocess.run(
-                ["git", "log", "-10", "--pretty=format:%H|%an|%ad|%s", "--date=short"],
+                ["git", "log", "-10", "--pretty=format:%H|%an|%ad|%s", "--date=format-local:%Y-%m-%d %H:%M"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,

--- a/usr/share/build-package/gui/widgets/overview_widget.py
+++ b/usr/share/build-package/gui/widgets/overview_widget.py
@@ -325,15 +325,20 @@ class OverviewWidget(Gtk.Box):
     
     def _update_changed_files_list(self, changed_files):
         """Update the expandable list of changed files"""
-        # Clear previous rows
-        child = self.changed_files_expander.get_first_child()
-        rows_to_remove = []
-        while child:
-            if isinstance(child, Adw.ActionRow) and child is not self.changed_files_expander:
-                rows_to_remove.append(child)
-            child = child.get_next_sibling()
-        for row in rows_to_remove:
+        # Clear previously added rows.
+        #
+        # Adw.ExpanderRow keeps add_row() children in an internal list box, so
+        # they are NOT reachable by walking get_first_child()/get_next_sibling()
+        # on the expander itself — that traversal only sees the expander's own
+        # header widgets. The old code therefore removed nothing, and every
+        # refresh (each "Pull Latest"/status update) appended the file list
+        # again, duplicating the entries. Track the rows we add and remove them
+        # explicitly instead.
+        if not hasattr(self, "_changed_file_rows"):
+            self._changed_file_rows = []
+        for row in self._changed_file_rows:
             self.changed_files_expander.remove(row)
+        self._changed_file_rows = []
 
         status_labels = {
             "M": _("Modified"),
@@ -365,6 +370,7 @@ class OverviewWidget(Gtk.Box):
             icon = Gtk.Image.new_from_icon_name(icon_name)
             row.add_prefix(icon)
             self.changed_files_expander.add_row(row)
+            self._changed_file_rows.append(row)
 
         count = len(changed_files)
         self.changed_files_expander.set_title(


### PR DESCRIPTION
## Summary

Two small fixes for the Build Package (bpkg) GTK interface.

### 1. Changed-files list duplicates on every refresh (bug)

The Overview's **Changed Files** expander re-listed the same files on every status refresh (each *Pull Latest* / branch switch), so after a couple of refreshes each file appeared two or three times.

**Root cause:** `_update_changed_files_list` cleared old rows by walking `changed_files_expander.get_first_child()` / `get_next_sibling()`. Rows added with `Adw.ExpanderRow.add_row()` live in the expander's **internal list box** and are not reachable that way — the traversal only sees the expander's own header widgets, so nothing was removed and every refresh appended the list again.

**Fix:** track the added rows in `self._changed_file_rows` and remove them explicitly before repopulating.

### 2. Commit history now shows the time (feature)

The **Commit History** list only showed the date (`--date=short`). Switched to `--date=format-local:%Y-%m-%d %H:%M` so each entry shows the local time too. The hash is already carried and shown (truncated) by `CommitRow`.

## Notes
- Both files pass `python -m py_compile`.
- Changes are limited to `overview_widget.py` and `advanced_widget.py`.