### PR TITLE
feat(welcome): modernize the welcome screen

### DIFF
--- a/usr/share/build-package/gui/dialogs/welcome_dialog.py
+++ b/usr/share/build-package/gui/dialogs/welcome_dialog.py
@@ -3,241 +3,234 @@
 #
 # gui/dialogs/welcome_dialog.py - Welcome dialog for first-time users
 #
+# Polish pass: same content as before (hero, key features, quick tips, the
+# "don't show again" choice and Get Started) re-laid-out with native libadwaita
+# components — Adw.ToolbarView + Adw.StatusPage hero, an Adw.PreferencesGroup of
+# features, and the tips folded into a collapsible row — so it reads as a clean,
+# modern onboarding screen instead of a scroll wall.
 
 import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 
-from gi.repository import Gtk, Adw, GObject
+from gi.repository import Gtk, Adw, GObject, Gdk
 from core.translation_utils import _
 from core.config import APP_NAME, APP_VERSION, APP_DESC
 
 
+# GTK4 has no CSS blur filter, so the "blur-ish" touches are a radial accent
+# glow behind the hero icon and a soft horizontal vignette that fades the
+# content into the left/right edges. Scoped to uniquely-named classes so they
+# only affect this dialog.
+_WELCOME_CSS = """
+.welcome-hero-glow {
+  padding: 16px;
+  border-radius: 999px;
+  background: radial-gradient(circle at center,
+                              alpha(@accent_bg_color, 0.30) 0%,
+                              transparent 70%);
+}
+.welcome-side-fade {
+  background: linear-gradient(to right,
+                              @window_bg_color 0%,
+                              transparent 18%,
+                              transparent 82%,
+                              @window_bg_color 100%);
+}
+"""
+
+
 class WelcomeDialog(Adw.Window):
     """Welcome dialog shown on first run or when user requests"""
-    
+
     __gsignals__ = {
         'closed': (GObject.SignalFlags.RUN_FIRST, None, (bool,)),  # show_again
     }
-    
+
     def __init__(self, parent, settings):
-        super().__init__(
-            transient_for=parent,
-            modal=True
-        )
-        
+        super().__init__(transient_for=parent, modal=True)
         self.settings = settings
-        
+
         self.set_title(_("Welcome"))
-        self.set_default_size(600, 500)
+        self.set_default_size(560, 660)
         self.set_resizable(False)
-        
+
+        self._install_css()
         self.create_ui()
-    
+
+    @staticmethod
+    def _install_css():
+        provider = Gtk.CssProvider()
+        provider.load_from_string(_WELCOME_CSS)
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
+
     def create_ui(self):
-        """Create the welcome dialog UI"""
-        
-        # Main container
-        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        self.set_content(main_box)
-        
-        # Header bar (minimal)
-        header_bar = Adw.HeaderBar()
-        header_bar.set_show_end_title_buttons(True)
-        header_bar.set_show_start_title_buttons(False)
-        main_box.append(header_bar)
-        
-        # Content with scroll
+        """Create the welcome dialog UI."""
+        view = Adw.ToolbarView()
+        self.set_content(view)
+
+        # Flat top bar — just the window controls, keeps focus on the hero.
+        header = Adw.HeaderBar()
+        header.add_css_class("flat")
+        view.add_top_bar(header)
+
+        overlay = Gtk.Overlay()
+        view.set_content(overlay)
+
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
-        main_box.append(scrolled)
-        
-        # Content box
-        content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=24)
-        content_box.set_margin_top(32)
-        content_box.set_margin_bottom(32)
-        content_box.set_margin_start(48)
-        content_box.set_margin_end(48)
-        content_box.set_halign(Gtk.Align.CENTER)
-        content_box.set_valign(Gtk.Align.START)
-        scrolled.set_child(content_box)
-        
-        # App icon/logo
-        icon_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        icon_box.set_halign(Gtk.Align.CENTER)
-        
-        app_icon = Gtk.Image.new_from_icon_name("package-x-generic-symbolic")
-        app_icon.set_pixel_size(80)
-        app_icon.add_css_class("accent")
-        icon_box.append(app_icon)
-        
-        content_box.append(icon_box)
-        
-        # Welcome title
-        title_label = Gtk.Label()
-        title_label.set_text(_("Welcome to {0}").format(APP_NAME))
-        title_label.add_css_class("title-1")
-        title_label.set_halign(Gtk.Align.CENTER)
-        content_box.append(title_label)
-        
-        # Version
-        version_label = Gtk.Label()
-        version_label.set_text(_("Version {0}").format(APP_VERSION))
-        version_label.add_css_class("dim-label")
-        version_label.set_halign(Gtk.Align.CENTER)
-        content_box.append(version_label)
-        
-        # Description
-        desc_label = Gtk.Label()
-        desc_label.set_text(APP_DESC)
-        desc_label.add_css_class("body")
-        desc_label.set_wrap(True)
-        desc_label.set_justify(Gtk.Justification.CENTER)
-        desc_label.set_halign(Gtk.Align.CENTER)
-        desc_label.set_max_width_chars(60)
-        content_box.append(desc_label)
-        
-        # Features section
-        features_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
-        features_box.set_margin_top(16)
-        
-        features_title = Gtk.Label()
-        features_title.set_text(_("Key Features"))
-        features_title.add_css_class("title-4")
-        features_title.set_halign(Gtk.Align.START)
-        features_box.append(features_title)
-        
+        overlay.set_child(scrolled)
+
+        clamp = Adw.Clamp()
+        clamp.set_maximum_size(460)
+        clamp.set_margin_top(4)
+        clamp.set_margin_bottom(24)
+        clamp.set_margin_start(16)
+        clamp.set_margin_end(16)
+        scrolled.set_child(clamp)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18)
+        clamp.set_child(content)
+
+        content.append(self._build_hero())
+        content.append(self._build_features())
+        content.append(self._build_tips())
+
+        # Side vignette on top of the scrolled content (click-through).
+        side_fade = Gtk.Box()
+        side_fade.add_css_class("welcome-side-fade")
+        side_fade.set_can_target(False)
+        overlay.add_overlay(side_fade)
+
+        view.add_bottom_bar(self._build_action_bar())
+
+    def _build_hero(self):
+        # Built by hand (instead of Adw.StatusPage) so the branded app icon
+        # keeps its colors and the title/description don't get swallowed by
+        # StatusPage's full-page vertical centering when embedded in a list.
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        box.set_halign(Gtk.Align.CENTER)
+        box.set_margin_top(18)
+        box.set_margin_bottom(4)
+
+        # Themed "package" glyph tinted with the accent colour — evokes package
+        # building without looking like a flat grey generic icon.
+        icon = Gtk.Image.new_from_icon_name("package-x-generic-symbolic")
+        icon.set_pixel_size(88)
+        icon.add_css_class("accent")
+
+        # Soft accent glow behind the icon.
+        glow = Gtk.Box()
+        glow.add_css_class("welcome-hero-glow")
+        glow.set_halign(Gtk.Align.CENTER)
+        glow.set_valign(Gtk.Align.CENTER)
+        glow.append(icon)
+        box.append(glow)
+
+        # The window title bar already says "Welcome", so the hero just shows the
+        # app name. APP_NAME is intentionally all-caps for the brand (and the CLI
+        # banner), but ALL CAPS reads as shouting in a hero — soften it to title
+        # case here without touching the global constant used elsewhere.
+        display_name = APP_NAME.title() if APP_NAME.isupper() else APP_NAME
+        title = Gtk.Label(label=display_name)
+        title.add_css_class("title-1")
+        title.set_justify(Gtk.Justification.CENTER)
+        title.set_wrap(True)
+        box.append(title)
+
+        version = Gtk.Label(label=_("Version {0}").format(APP_VERSION))
+        version.add_css_class("dim-label")
+        version.add_css_class("caption")
+        box.append(version)
+
+        description = Gtk.Label(label=APP_DESC)
+        description.add_css_class("body")
+        description.set_wrap(True)
+        description.set_justify(Gtk.Justification.CENTER)
+        description.set_max_width_chars(48)
+        description.set_margin_top(4)
+        box.append(description)
+        return box
+
+    def _build_features(self):
+        group = Adw.PreferencesGroup()
+        group.set_title(_("Key Features"))
+
         features = [
-            ("document-save-symbolic", _("Commit and Push"), 
+            ("document-save-symbolic", _("Commit and Push"),
              _("Stage changes and push to your development branch with semantic commit messages")),
-            ("package-x-generic-symbolic", _("Build Packages"), 
+            ("package-x-generic-symbolic", _("Build Packages"),
              _("Build and deploy packages to testing, stable, or extra repositories")),
-            ("system-software-install-symbolic", _("AUR Packages"), 
+            ("system-software-install-symbolic", _("AUR Packages"),
              _("Build packages directly from the Arch User Repository")),
-            ("media-playlist-consecutive-symbolic", _("Branch Management"), 
+            ("media-playlist-consecutive-symbolic", _("Branch Management"),
              _("Manage branches, create merge requests, and cleanup old branches")),
-            ("preferences-system-symbolic", _("Advanced Operations"), 
+            ("preferences-system-symbolic", _("Advanced Operations"),
              _("Cleanup GitHub Actions, tags, and revert commits")),
         ]
-        
         for icon_name, title, description in features:
-            feature_row = self._create_feature_row(icon_name, title, description)
-            features_box.append(feature_row)
-        
-        content_box.append(features_box)
-        
-        # Tips section
-        tips_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
-        tips_box.set_margin_top(16)
-        
-        tips_title = Gtk.Label()
-        tips_title.set_text(_("Quick Tips"))
-        tips_title.add_css_class("title-4")
-        tips_title.set_halign(Gtk.Align.START)
-        tips_box.append(tips_title)
-        
+            row = Adw.ActionRow()
+            row.set_title(title)
+            row.set_subtitle(description)
+            row.set_subtitle_lines(0)
+            icon = Gtk.Image.new_from_icon_name(icon_name)
+            icon.add_css_class("accent")
+            row.add_prefix(icon)
+            group.add(row)
+        return group
+
+    def _build_tips(self):
+        group = Adw.PreferencesGroup()
+
+        expander = Adw.ExpanderRow()
+        expander.set_title(_("Quick Tips"))
+        expander.add_prefix(Gtk.Image.new_from_icon_name("dialog-information-symbolic"))
+
         tips = [
             _("Use the sidebar to navigate between different operations"),
             _("The Overview page shows your current repository status"),
             _("Configure your preferences in Settings (Ctrl+,)"),
             _("Press Ctrl+Q to quit the application"),
         ]
-        
         for tip in tips:
-            tip_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-            
-            bullet = Gtk.Label()
-            bullet.set_text("•")
-            bullet.add_css_class("accent")
-            bullet.set_valign(Gtk.Align.START)
-            tip_row.append(bullet)
-            
-            tip_label = Gtk.Label()
-            tip_label.set_text(tip)
-            tip_label.set_wrap(True)
-            tip_label.set_xalign(0)
-            tip_label.set_hexpand(True)
-            tip_row.append(tip_label)
-            
-            tips_box.append(tip_row)
-        
-        content_box.append(tips_box)
-        
-        # Bottom section with checkbox and button
-        bottom_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
-        bottom_box.set_margin_top(24)
-        main_box.append(bottom_box)
-        
-        # Separator
-        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
-        bottom_box.append(separator)
-        
-        # Actions box
-        actions_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        actions_box.set_margin_top(16)
-        actions_box.set_margin_bottom(16)
-        actions_box.set_margin_start(24)
-        actions_box.set_margin_end(24)
-        
-        # Don't show again checkbox
+            row = Adw.ActionRow()
+            row.set_title(tip)
+            row.set_title_lines(0)
+            expander.add_row(row)
+
+        group.add(expander)
+        return group
+
+    def _build_action_bar(self):
+        bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        bar.set_margin_top(10)
+        bar.set_margin_bottom(10)
+        bar.set_margin_start(14)
+        bar.set_margin_end(14)
+
         self.dont_show_check = Gtk.CheckButton()
         self.dont_show_check.set_label(_("Don't show this welcome screen again"))
         self.dont_show_check.set_hexpand(True)
-        actions_box.append(self.dont_show_check)
-        
-        # Get started button
+        self.dont_show_check.set_valign(Gtk.Align.CENTER)
+        bar.append(self.dont_show_check)
+
         start_button = Gtk.Button()
         start_button.set_label(_("Get Started"))
         start_button.add_css_class("suggested-action")
         start_button.add_css_class("pill")
         start_button.connect('clicked', self.on_start_clicked)
-        actions_box.append(start_button)
-        
-        bottom_box.append(actions_box)
-    
-    def _create_feature_row(self, icon_name, title, description):
-        """Create a feature row with icon, title, and description"""
-        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        row.set_margin_start(8)
-        row.set_margin_end(8)
-        
-        # Icon
-        icon = Gtk.Image.new_from_icon_name(icon_name)
-        icon.set_pixel_size(32)
-        icon.add_css_class("accent")
-        icon.set_valign(Gtk.Align.CENTER)
-        row.append(icon)
-        
-        # Text box
-        text_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
-        text_box.set_hexpand(True)
-        
-        title_label = Gtk.Label()
-        title_label.set_text(title)
-        title_label.add_css_class("heading")
-        title_label.set_xalign(0)
-        text_box.append(title_label)
-        
-        desc_label = Gtk.Label()
-        desc_label.set_text(description)
-        desc_label.add_css_class("dim-label")
-        desc_label.set_wrap(True)
-        desc_label.set_xalign(0)
-        text_box.append(desc_label)
-        
-        row.append(text_box)
-        
-        return row
-    
+        bar.append(start_button)
+        return bar
+
     def on_start_clicked(self, button):
         """Handle Get Started button click"""
         show_again = not self.dont_show_check.get_active()
-        
-        # Save preference
         self.settings.set("show_welcome", show_again)
-        
-        # Emit signal and close
         self.emit('closed', show_again)
         self.close()
 


### PR DESCRIPTION
Polish pass on the first-run welcome screen using native libadwaita components. Same content as before (hero, key features, quick tips, "don't show again" + Get Started), re-laid-out:

- Adw.ToolbarView shell with a flat header and a bottom action bar
- Hand-built hero: accent-tinted package icon with a soft radial glow, app name in title case (the title bar still says "Welcome")
- Key Features as an Adw.PreferencesGroup of icon rows
- Quick Tips folded into a collapsible expander
- Subtle horizontal vignette fading the content into the side edges (GTK4 has no CSS blur)

No content removed; global APP_NAME left untouched.
